### PR TITLE
Prepare repository for first public release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,17 @@
-# Exclude generator and dev files from Packagist distribution
-/generator              export-ignore
+# Exclude dev-only files and directories from Composer package distribution
+
+# Directories
 /.claude                export-ignore
+/.github                export-ignore
 /.idea                  export-ignore
+/generator              export-ignore
+
+# Files
 /.gitattributes         export-ignore
+/.gitignore             export-ignore
+/composer.lock          export-ignore
+/CONTRIBUTING.md        export-ignore
 /phpstan.neon           export-ignore
+
+# Patterns
 *.DS_Store              export-ignore

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,27 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - uses: ramsey/composer-install@v3

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
     name: PHPStan - PHP ${{ matrix.php }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,34 @@
+name: PHPStan
+
+on:
+  pull_request:
+    branches:
+      - trunk
+  push:
+    branches:
+      - trunk
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+    name: PHPStan - PHP ${{ matrix.php }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - uses: ramsey/composer-install@v3
+
+      - run: composer validate --strict
+
+      - run: composer analyse

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHPStan - PHP ${{ matrix.php }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -1,0 +1,92 @@
+name: Props Bot
+
+on:
+  # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
+  # GitHub does not allow filtering the `labeled` event by a specific label.
+  # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
+  # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
+  # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
+  # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - ready_for_review
+  # This event runs anytime a comment is added or deleted.
+  # You cannot filter this event for PR comments only.
+  # However, the logic below does short-circuit the workflow for issues.
+  issue_comment:
+    types:
+      - created
+  # This event will run everytime a new PR review is initially submitted.
+  pull_request_review:
+    types:
+      - submitted
+  # This event runs anytime a PR review comment is created or deleted.
+  pull_request_review_comment:
+    types:
+      - created
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ contains( fromJSON( '["pull_request_target", "pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  # Compiles a list of props for a pull request.
+  #
+  # Performs the following steps:
+  # - Collects a list of contributor props and leaves a comment.
+  # - Removes the props-bot label, if necessary.
+  props-bot:
+    name: Generate a list of props
+    runs-on: ubuntu-24.04
+    permissions:
+      # The action needs permission `write` permission for PRs in order to add a comment.
+      pull-requests: write
+      contents: read
+    timeout-minutes: 20
+    # The job will run when pull requests are open, ready for review and:
+    #
+    # - A comment is added to the pull request.
+    # - A review is created or commented on (unless PR originates from a fork).
+    # - The pull request is opened, synchronized, marked ready for review, or reopened.
+    # - The `props-bot` label is added to the pull request.
+    if: |
+      (
+        github.event_name == 'issue_comment' && github.event.issue.pull_request ||
+        ( contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) && ! github.event.pull_request.head.repo.fork ) ||
+        github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+        'props-bot' == github.event.label.name
+      ) &&
+      ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
+
+    steps:
+      - name: Gather a list of contributors
+        uses: WordPress/props-bot-action@trunk
+        with:
+          format: 'git'
+
+      - name: Remove the props-bot label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: ${{ github.event.action == 'labeled' && 'props-bot' == github.event.label.name }}
+        with:
+          retries: 2
+          retry-exempt-status-codes: 418
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: process.env.ISSUE_NUMBER,
+              name: 'props-bot'
+            });
+        env:
+          ISSUE_NUMBER: ${{ github.event.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - Unreleased
+
+### Added
+
+- PHP 7.4+ Data Transfer Objects (DTOs) for the Model Context Protocol (MCP) 2025-11-25 specification
+- `fromArray()` static factory methods for deserializing arrays into typed DTOs
+- `toArray()` methods for serializing DTOs to arrays suitable for `json_encode()`
+- Factory classes for union/polymorphic type resolution
+- Class-based enums for MCP enumerated values (PHP 7.4 compatible)
+- Complete MCP domain coverage: Server (Tools, Resources, Prompts, Logging), Client (Sampling, Elicitation, Roots), Common (JSON-RPC, Protocol, Content)
+- JSON-RPC 2.0 message types (Request, Notification, Result, Error)
+- PSR-4 autoloading under `WP\McpSchema\` namespace
+- PHPStan level max static analysis validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to PHP MCP Schema
+
+Thank you for your interest in contributing! Please [open an issue](https://github.com/WordPress/php-mcp-schema/issues) to discuss bugs, questions, or feature ideas before sending a pull request.
+
+---
+
+## Architecture Overview
+
+`src/` contains PHP DTOs that are **auto-generated** from the official [MCP TypeScript schema](https://github.com/modelcontextprotocol/modelcontextprotocol). The generator lives in `generator/` and is excluded from the Composer package.
+
+> **Warning: Never edit files in `src/` directly.**
+> Any manual changes will be overwritten the next time the generator runs.
+> All PHP output changes must go through the generator.
+
+---
+
+## Contributing Changes to PHP Output
+
+Use this workflow when your change affects the generated PHP code (new types, property fixes, serialization logic, etc.).
+
+**Requirements:** Node.js >= 18, npm
+
+```bash
+# 1. Navigate to the generator
+cd generator
+
+# 2. Install dependencies (first time only)
+npm install
+
+# 3. Make your changes in generator/src/
+
+# 4. Build the TypeScript
+npm run build
+
+# 5. Regenerate PHP files into src/
+npm run generate
+
+# 6. Validate from the repo root
+cd ..
+composer analyse
+```
+
+The `npm run generate:check` convenience script (run from `generator/`) combines steps 5 and 6 in one command.
+
+---
+
+## Contributing Non-Generated Changes
+
+For changes to the README, CI configuration, `composer.json`, or other non-generated files, use the standard fork-and-PR workflow — no generator steps needed.
+
+---
+
+## Running Validation
+
+```bash
+# Static analysis (PHPStan level max, 0 errors expected)
+composer analyse
+
+# Validate composer.json
+composer validate --strict
+```
+
+Both commands run from the repo root.
+
+---
+
+## Pull Request Guidelines
+
+- **One concern per PR.** Keep changes focused.
+- **Descriptive title.** Summarize what changed and why.
+- **CI must pass.** PHPStan and other checks run automatically on every PR.
+- **For PHP output changes:** include the regenerated `src/` files in the same commit as the generator changes.
+
+---
+
+## Requirements
+
+| Tool | Minimum version |
+|------|----------------|
+| PHP | 7.4 |
+| Composer | 2.x |
+| Node.js | 18 (generator only) |

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,11 @@ Requires PHP 7.4 or higher.
 
 ## Usage
 
-```php
-use WP\McpSchema\Server\Tools\Tool;
-use WP\McpSchema\Server\Tools\CallToolRequest;
-use WP\McpSchema\Common\Content\TextContent;
+### Creating a Tool Definition
 
-// Create a tool definition
+```php
+use WP\McpSchema\Server\Tools\DTO\Tool;
+
 $tool = Tool::fromArray([
     'name' => 'get_weather',
     'description' => 'Get current weather for a location',
@@ -33,6 +32,70 @@ $tool = Tool::fromArray([
         'required' => ['location'],
     ],
 ]);
+```
+
+### Serialization (toArray)
+
+Convert a DTO to a plain array for JSON encoding:
+
+```php
+use WP\McpSchema\Server\Tools\DTO\Tool;
+
+$tool = Tool::fromArray([
+    'name' => 'get_weather',
+    'description' => 'Get current weather for a location',
+    'inputSchema' => ['type' => 'object', 'properties' => []],
+]);
+
+$array = $tool->toArray();
+$json  = json_encode($array); // Ready to send over the wire
+```
+
+### Deserialization (fromArray)
+
+Decode incoming JSON into a fully typed DTO:
+
+```php
+use WP\McpSchema\Server\Tools\DTO\CallToolRequest;
+
+$json = '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_weather","arguments":{"location":"Paris"}}}';
+$data = json_decode($json, true);
+
+$request   = CallToolRequest::fromArray($data);
+$tool_name = $request->getTypedParams()->getName(); // "get_weather"
+$arguments = $request->getTypedParams()->getArguments(); // ['location' => 'Paris']
+```
+
+### Factory / Union Types
+
+Use a factory to resolve polymorphic content blocks without knowing the concrete type up front:
+
+```php
+use WP\McpSchema\Common\Protocol\Factory\ContentBlockFactory;
+use WP\McpSchema\Common\Content\DTO\TextContent;
+
+$block = ContentBlockFactory::fromArray(['type' => 'text', 'text' => 'Hello, world!']);
+
+// $block implements ContentBlockInterface; cast when you need the concrete API
+if ($block instanceof TextContent) {
+    echo $block->getText(); // "Hello, world!"
+}
+```
+
+### JSON-RPC Messages
+
+Construct a generic JSON-RPC request for any MCP method:
+
+```php
+use WP\McpSchema\Common\JsonRpc\DTO\JSONRPCRequest;
+
+$request = JSONRPCRequest::fromArray([
+    'jsonrpc' => '2.0',
+    'id'      => 1,
+    'method'  => 'tools/list',
+]);
+
+$json = json_encode($request->toArray());
 ```
 
 ## Available Types

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See [generator/README.md](generator/README.md) for setup and usage instructions.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+GPL-2.0-or-later - see [LICENSE.md](LICENSE.md) for details.
 
 ## Links
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wordpress/php-mcp-schema",
     "description": "PHP DTOs for the Model Context Protocol (MCP) specification",
     "type": "library",
-    "license": "MIT",
+    "license": "GPL-2.0-or-later",
     "keywords": [
         "mcp",
         "model-context-protocol",

--- a/composer.lock
+++ b/composer.lock
@@ -4,16 +4,16 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68b71570b5641a18d3a40e18e1019722",
+    "content-hash": "5cacc6201dab9adc333cdc5940bc9e72",
     "packages": [],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.32",
+            "version": "1.12.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2770dcdf5078d0b0d53f94317e06affe88419aa8",
-                "reference": "2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
                 "shasum": ""
             },
             "require": {
@@ -58,7 +58,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-30T10:16:31+00:00"
+            "time": "2026-02-28T20:30:03+00:00"
         }
     ],
     "aliases": [],

--- a/generator/package.json
+++ b/generator/package.json
@@ -28,7 +28,7 @@
     "typescript"
   ],
   "author": "Automattic",
-  "license": "MIT",
+  "license": "GPL-2.0-or-later",
   "repository": {
     "type": "git",
     "url": "https://github.com/WordPress/php-mcp-schema.git"


### PR DESCRIPTION
## What

Add all standard open-source project files and CI infrastructure to prepare the `wordpress/php-mcp-schema` Composer package for its first public release (v0.1.0).

### Changes

**License & Legal**
- Add `LICENSE.md` with full GPL v2 text (WordPress ecosystem standard)
- Update SPDX identifier from `MIT` to `GPL-2.0-or-later` in `composer.json` and `generator/package.json`
- Update README license section to reference GPL-2.0-or-later and link to `LICENSE.md`

**Documentation**
- Add `CHANGELOG.md` with initial 0.1.0 release entry (Keep a Changelog format)
- Add `CONTRIBUTING.md` with generator workflow instructions and the critical warning to never edit `src/` directly
- Expand `README.md` with usage examples: `toArray()` serialization, `fromArray()` deserialization, factory/union types (`ContentBlockFactory`), and JSON-RPC messages — all with correct `DTO\` namespaces verified against source

**CI & Tooling**
- Add PHPStan GitHub Actions workflow with PHP 7.4–8.4 matrix, concurrency groups, `composer validate --strict` and `composer analyse`
- Add Props Bot workflow for automated contributor attribution
- Add Copilot Setup Steps workflow for GitHub Copilot coding agents
- Configure 22 structured issue labels matching the mcp-adapter scheme

**Distribution**
- Expand `.gitattributes` export-ignore rules for `.github/`, `.gitignore`, `composer.lock`, `CONTRIBUTING.md` — organized into logical groups

## Why

The package needs standard open-source project infrastructure before its first Packagist release. GPL-2.0-or-later aligns with the WordPress ecosystem. CI ensures PHPStan validation on every PR. Documentation helps contributors understand the generator-based workflow.

## Notes

- Two items require WordPress org admin access: setting repo topics and disabling wiki
- All PHP code in `src/` is untouched — these are documentation, CI, and config changes only
- `composer.lock` updated due to phpstan minor patch bump (1.12.32 → 1.12.33)