### PR TITLE
build: exclude skill/ folder from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /.github                export-ignore
 /.idea                  export-ignore
 /generator              export-ignore
+/skill                  export-ignore
 
 # Files
 /.gitattributes         export-ignore


### PR DESCRIPTION
## What

Add `/skill  export-ignore` to `.gitattributes` so the `skill/` folder is
excluded from `git archive` output — which is what Packagist uses to build
the dist tarball for each tagged release.

## Why

A downstream report surfaced that WordPress.org's plugin review bot
auto-rejects plugin submissions that transitively depend on this package
(via `wordpress/mcp-adapter`) because the dist tarball ships three
executable shell scripts:

- `skill/scripts/search-types.sh`
- `skill/scripts/get-type.sh`
- `skill/scripts/find-rpc.sh`

These are part of a Claude Code skill pack (SKILL.md + helper scripts for
navigating the generated DTOs). They are pure dev tooling and have zero
runtime purpose for package consumers.

The repo already uses the same mechanism to keep `generator/` out of the
dist tarball. The `skill/` folder was added later and nobody registered it
with `export-ignore`, so `git archive` happily included the whole thing.

## Approach

Exclude the entire `/skill` directory — not just `skill/scripts/` — to
match the existing `/generator` precedent. The rest of `skill/` (SKILL.md,
data/, reference/) is also dev-only, and ignoring the folder as a unit
protects against the review bot flagging other content (data files,
markdown, etc.) in the future.

## Verification

Simulated what Packagist will build, locally:

```bash
git archive --format=tar HEAD | tar t | grep -E '(skill|\.sh)'
# → zero matches (grep exits 1)

git archive --format=tar HEAD | tar t | grep '^src/' | head
# → src/ tree still present (the actual package payload)
```

`git archive` reads `.gitattributes` from the committed tree at `HEAD`, so
running this on the fix branch after the commit is an accurate preview of
what Packagist will produce for the next tag.

## Notes

- No changes to `src/` — these are auto-generated by the TypeScript
  generator in `generator/` and must not be hand-edited.
- The `skill/` folder itself is kept in the repo; it's useful for
  contributors working on the package with AI assistance. This PR only
  keeps it out of the *distributed* tarball.
- A patch release tag is required after merge — without a new tag,
  Packagist will keep serving the old broken dist archive.
- Downstream `wordpress/mcp-adapter` will need a `composer.json`
  constraint bump once the new release is published, but that's a
  separate task in a separate repo.