### PR TITLE
build: exclude CLAUDE.md from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 # Files
 /.gitattributes         export-ignore
 /.gitignore             export-ignore
+/CLAUDE.md              export-ignore
 /composer.lock          export-ignore
 /CONTRIBUTING.md        export-ignore
 /phpstan.neon           export-ignore


### PR DESCRIPTION
## What

Add `/CLAUDE.md  export-ignore` to the Files section of `.gitattributes`
so `CLAUDE.md` is excluded from `git archive` output — the tarball
Packagist builds for each tagged release.

## Why

`CLAUDE.md` contains Claude Code project instructions for contributors
working on this repo with AI assistance. Like `CONTRIBUTING.md` and
`phpstan.neon` (already excluded), it has zero runtime purpose for
package consumers and only bloats the dist tarball that ships to
downstream projects via Composer.

This is a cleanup in the same spirit as #4, which excludes the
`skill/` folder. Both changes trim dev-only tooling out of the
distributed package.

## Approach

Add the entry to the existing `# Files` section in alphabetical order
(between `.gitignore` and `composer.lock`), matching the convention
already established by the reorganized `.gitattributes` layout.

## Verification

Simulated what Packagist will build, locally:

```bash
git archive --format=tar HEAD | tar t | grep -i claude
# → zero matches (grep exits 1)
```

## Notes

- No changes to `src/` — these are auto-generated by the TypeScript
  generator and must not be hand-edited.
- `CLAUDE.md` itself stays in the repo; it's useful for contributors.
  This PR only keeps it out of the *distributed* tarball.
- A patch release tag is required after merge to publish a clean dist
  archive. This change can ship together with #4 under the same tag.