### PR TITLE
docs: update CHANGELOG for 0.1.1 and backfill 0.1.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - Unreleased
+## [0.1.1] - 2026-04-10
+
+### Fixed
+
+- Exclude `skill/` directory from Composer dist archives. It contains dev-only helper scripts and reference docs that have no runtime purpose for package consumers and should not ship in the `vendor/` folder.
+- Exclude `CLAUDE.md` from Composer dist archives. It contains dev-only project instructions with no runtime purpose for package consumers.
+
+## [0.1.0] - 2026-03-02
 
 ### Added
 


### PR DESCRIPTION
## What

- Add a `0.1.1` entry to `CHANGELOG.md` covering the two dist-archive
  fixes that shipped in that version (#4, #5).
- Backfill the `0.1.0` release date (2026-03-02). The entry was still
  marked `Unreleased` even though the tag was published.

## Why

The changelog was out of sync with the actual release history:

- `0.1.0` had been tagged and published on Packagist but its changelog
  heading still read `## [0.1.0] - Unreleased`.
- `0.1.1` had no changelog entry at all, even though the tag was
  created to ship the `skill/` and `CLAUDE.md` exclusions.

This PR brings `CHANGELOG.md` back in line with the published tags so
future releases have a correct starting point.

## New section

```markdown
## [0.1.1] - 2026-04-10

### Fixed

- Exclude `skill/` directory from Composer dist archives. It contains
  dev-only helper scripts and reference docs that have no runtime
  purpose for package consumers and should not ship in the `vendor/`
  folder.
- Exclude `CLAUDE.md` from Composer dist archives. It contains
  dev-only project instructions with no runtime purpose for package
  consumers.
```

## Notes

- Docs-only change. No code, no CI, no generated files touched.
- After this merges, the `v0.1.1` tag needs to be moved to the new
  trunk tip so the published release actually contains this updated
  CHANGELOG. That re-tagging is a separate follow-up step outside
  this PR.