### PR TITLE
fix: emit empty tool schema properties as JSON object

### DIFF
--- a/generator/package-lock.json
+++ b/generator/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@wordpress/php-mcp-schema-generator",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0",

--- a/generator/src/generators/dto.ts
+++ b/generator/src/generators/dto.ts
@@ -119,15 +119,15 @@ export class DtoGenerator {
     const narrowedProperties = propClassification.narrowedProperties;
 
     // Resolve all property types and collect imports (for constructor/fromArray/toArray)
-    const allPhpProperties = allProperties.map((p) => this.resolveProperty(p, currentNamespace, imports));
+    const allPhpProperties = allProperties.map((p) => this.resolveProperty(p, currentNamespace, imports, iface.name));
 
     // Resolve own property types (for property declarations)
-    const ownPhpProperties = ownProperties.map((p) => this.resolveProperty(p, currentNamespace, imports));
+    const ownPhpProperties = ownProperties.map((p) => this.resolveProperty(p, currentNamespace, imports, iface.name));
 
     // Resolve narrowed property types (for property declarations and special handling)
     const narrowedPhpProperties = narrowedProperties.map((n) => ({
       narrowed: n,
-      phpProperty: this.resolveProperty(n.property, currentNamespace, imports),
+      phpProperty: this.resolveProperty(n.property, currentNamespace, imports, iface.name),
     }));
 
     const indent = this.getIndent();
@@ -154,7 +154,8 @@ export class DtoGenerator {
   private resolveProperty(
     p: { name: string; type: string; isOptional: boolean; description?: string },
     currentNamespace: string,
-    imports: Map<string, string>
+    imports: Map<string, string>,
+    interfaceName?: string
   ): PhpProperty {
     const resolved = this.typeResolver.resolve(p.type, p.name);
     let phpType = resolved.phpType;
@@ -234,7 +235,22 @@ export class DtoGenerator {
       isRequired: !p.isOptional,
       constValue,
       maxItems,
+      serializeEmptyAsObject: this.shouldSerializeEmptyAsObject(interfaceName, p.name),
     } as PhpProperty;
+  }
+
+  /**
+   * Tool input/output JSON Schemas must keep an object-typed properties key on
+   * the wire, even when no parameters are declared.
+   */
+  private shouldSerializeEmptyAsObject(
+    interfaceName: string | undefined,
+    propertyName: string
+  ): boolean {
+    return (
+      propertyName === 'properties' &&
+      (interfaceName === 'ToolInputSchema' || interfaceName === 'ToolOutputSchema')
+    );
   }
 
   /**
@@ -446,7 +462,7 @@ export class DtoGenerator {
     // toArray method - for child classes, call parent::toArray() and merge own + narrowed properties
     // Both own and narrowed need to be serialized by the child class
     const propsToSerialize = [...(ownProperties ?? []), ...narrowedPhpProperties];
-    lines.push(...this.renderToArray(meta.properties, indent, propsToSerialize, isRootType, interfaceName));
+    lines.push(...this.renderToArray(meta.properties, indent, propsToSerialize, isRootType));
 
     // Getters (only for own properties)
     if (this.options.generateGetters && propertiesToDeclare.length > 0) {
@@ -1156,17 +1172,8 @@ export class DtoGenerator {
     properties: readonly PhpProperty[],
     indent: string,
     ownProperties: readonly PhpProperty[] = [],
-    isRootType: boolean = true,
-    interfaceName?: string
+    isRootType: boolean = true
   ): string[] {
-    /**
-     * Tool input/output JSON Schemas must always emit an object-typed
-     * `properties` key on the wire (e.g. `{}`), not omit it or emit `[]`.
-     * Strict JSON-Schema validators (OpenAI strict function-calling) reject
-     * tools whose root object schema is missing `properties`.
-     */
-    const forcePropertiesAsObject =
-      interfaceName === 'ToolInputSchema' || interfaceName === 'ToolOutputSchema';
     const lines: string[] = [];
 
     lines.push(`${indent}/**`);
@@ -1204,7 +1211,7 @@ export class DtoGenerator {
       // Determine serialization method based on type
       const serializationExpr = this.getSerializationExpression(prop.type, `$this->${phpName}`);
 
-      if (forcePropertiesAsObject && jsonKey === 'properties') {
+      if (prop.serializeEmptyAsObject) {
         lines.push(
           `${indent}${indent}$result['${jsonKey}'] = !empty($this->${phpName})`
         );

--- a/generator/src/generators/dto.ts
+++ b/generator/src/generators/dto.ts
@@ -446,7 +446,7 @@ export class DtoGenerator {
     // toArray method - for child classes, call parent::toArray() and merge own + narrowed properties
     // Both own and narrowed need to be serialized by the child class
     const propsToSerialize = [...(ownProperties ?? []), ...narrowedPhpProperties];
-    lines.push(...this.renderToArray(meta.properties, indent, propsToSerialize, isRootType));
+    lines.push(...this.renderToArray(meta.properties, indent, propsToSerialize, isRootType, interfaceName));
 
     // Getters (only for own properties)
     if (this.options.generateGetters && propertiesToDeclare.length > 0) {
@@ -1156,8 +1156,17 @@ export class DtoGenerator {
     properties: readonly PhpProperty[],
     indent: string,
     ownProperties: readonly PhpProperty[] = [],
-    isRootType: boolean = true
+    isRootType: boolean = true,
+    interfaceName?: string
   ): string[] {
+    /**
+     * Tool input/output JSON Schemas must always emit an object-typed
+     * `properties` key on the wire (e.g. `{}`), not omit it or emit `[]`.
+     * Strict JSON-Schema validators (OpenAI strict function-calling) reject
+     * tools whose root object schema is missing `properties`.
+     */
+    const forcePropertiesAsObject =
+      interfaceName === 'ToolInputSchema' || interfaceName === 'ToolOutputSchema';
     const lines: string[] = [];
 
     lines.push(`${indent}/**`);
@@ -1195,7 +1204,13 @@ export class DtoGenerator {
       // Determine serialization method based on type
       const serializationExpr = this.getSerializationExpression(prop.type, `$this->${phpName}`);
 
-      if (prop.type.nullable || !prop.isRequired) {
+      if (forcePropertiesAsObject && jsonKey === 'properties') {
+        lines.push(
+          `${indent}${indent}$result['${jsonKey}'] = !empty($this->${phpName})`
+        );
+        lines.push(`${indent}${indent}${indent}? ${serializationExpr}`);
+        lines.push(`${indent}${indent}${indent}: new \\stdClass();`);
+      } else if (prop.type.nullable || !prop.isRequired) {
         lines.push(`${indent}${indent}if ($this->${phpName} !== null) {`);
         lines.push(`${indent}${indent}${indent}$result['${jsonKey}'] = ${serializationExpr};`);
         lines.push(`${indent}${indent}}`);

--- a/generator/src/types/index.ts
+++ b/generator/src/types/index.ts
@@ -185,6 +185,11 @@ export interface PhpProperty {
    * Used to generate validation in fromArray().
    */
   readonly maxItems?: number;
+  /**
+   * When true, empty values serialize as stdClass so json_encode() emits
+   * an object ({}) instead of an array ([]).
+   */
+  readonly serializeEmptyAsObject?: boolean;
 }
 
 /**

--- a/src/Server/Tools/DTO/ToolInputSchema.php
+++ b/src/Server/Tools/DTO/ToolInputSchema.php
@@ -90,9 +90,9 @@ class ToolInputSchema extends AbstractDataTransferObject
             $result['$schema'] = $this->schema;
         }
         $result['type'] = $this->type;
-        if ($this->properties !== null) {
-            $result['properties'] = $this->properties;
-        }
+        $result['properties'] = !empty($this->properties)
+            ? $this->properties
+            : new \stdClass();
         if ($this->required !== null) {
             $result['required'] = $this->required;
         }

--- a/src/Server/Tools/DTO/ToolOutputSchema.php
+++ b/src/Server/Tools/DTO/ToolOutputSchema.php
@@ -94,9 +94,9 @@ class ToolOutputSchema extends AbstractDataTransferObject
             $result['$schema'] = $this->schema;
         }
         $result['type'] = $this->type;
-        if ($this->properties !== null) {
-            $result['properties'] = $this->properties;
-        }
+        $result['properties'] = !empty($this->properties)
+            ? $this->properties
+            : new \stdClass();
         if ($this->required !== null) {
             $result['required'] = $this->required;
         }


### PR DESCRIPTION
## Summary

- `ToolInputSchema::toArray()` and `ToolOutputSchema::toArray()` now always emit the `properties` key on the wire, encoded as a JSON object (`{}`) when the tool declares no parameters.
- Mirrored in the TypeScript generator so a clean regen reproduces the patched output.
- `generator/package-lock.json` was refreshed by a clean `npm install` during the regen.

## Why

Parameter-less tools previously produced one of two invalid wire shapes:

- `properties = null` → key omitted entirely → `{"type":"object"}`
- `properties = []` → emitted as JSON array → `"properties":[]`

Strict JSON Schema validators reject both. The most visible failure is OpenAI strict function-calling mode:

> `Invalid schema for function '<tool>': In context=(), object schema missing properties.`

Tools with real parameters serialize unchanged — only the empty/null case changes.

## Implementation notes

In `toArray()`, the previous `if ($this->properties !== null)` gate was replaced with an unconditional emit:

```php
$result['properties'] = !empty($this->properties)
    ? $this->properties
    : new \stdClass();
```

`stdClass` is used for the empty case so `json_encode()` produces `{}` rather than `[]`. Field types (`?array $properties`) are unchanged; constructor and `fromArray()` are unchanged.

The TypeScript generator (`generator/src/generators/dto.ts`) emits this shape only for `ToolInputSchema` and `ToolOutputSchema` — every other DTO uses the original conditional emit.

## Test plan

- [x] `composer analyse` (PHPStan level max) — clean
- [x] Manual: `new ToolInputSchema()` and `new ToolInputSchema(null, [])` both produce `"properties":{}` under `json_encode(toArray())`
- [x] Manual: `new ToolInputSchema(null, ['name' => $obj], ['name'])` round-trips with `"properties":{"name":...}`
- [x] Same checks for `ToolOutputSchema`
- [x] Generator regenerated cleanly (`npm install && npm run build && node dist/cli/index.js generate -c config/2025-11-25.json`); generated PHP matches the hand-edit