### PR TITLE
build: analyse with PHPStan 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cacc6201dab9adc333cdc5940bc9e72",
+    "content-hash": "ff796c978e3cf65ea771db553722ab74",
     "packages": [],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.33",
+            "version": "2.2.7",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
-                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/692db47b9dddb0487934e5236e77d48594aef921",
+                "reference": "692db47b9dddb0487934e5236e77d48594aef921",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -35,6 +35,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -58,7 +69,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T20:30:03+00:00"
+            "time": "2026-07-29T17:39:32+00:00"
         }
     ],
     "aliases": [],

--- a/generator/src/generators/dto.ts
+++ b/generator/src/generators/dto.ts
@@ -1078,7 +1078,7 @@ export class DtoGenerator {
               const dataExpr = deserExpr.varExpr ?? rawExpr;
               variableAssignments.push(`${indent}${indent}${varName} = array_map(`);
               variableAssignments.push(`${indent}${indent}${indent}static fn($item) => is_array($item)`);
-              variableAssignments.push(`${indent}${indent}${indent}${indent}? ${deserExpr.dtoHydrator}::fromArray($item)`);
+              variableAssignments.push(`${indent}${indent}${indent}${indent}? ${deserExpr.dtoHydrator}::fromArray(self::asArray($item))`);
               variableAssignments.push(`${indent}${indent}${indent}${indent}: $item,`);
               variableAssignments.push(`${indent}${indent}${indent}self::asArray(${dataExpr})`);
               variableAssignments.push(`${indent}${indent});`);
@@ -1116,7 +1116,7 @@ export class DtoGenerator {
               const dataExpr = deserExpr.varExpr ?? rawExpr;
               variableAssignments.push(`${indent}${indent}${indent}? array_map(`);
               variableAssignments.push(`${indent}${indent}${indent}${indent}static fn($item) => is_array($item)`);
-              variableAssignments.push(`${indent}${indent}${indent}${indent}${indent}? ${deserExpr.dtoHydrator}::fromArray($item)`);
+              variableAssignments.push(`${indent}${indent}${indent}${indent}${indent}? ${deserExpr.dtoHydrator}::fromArray(self::asArray($item))`);
               variableAssignments.push(`${indent}${indent}${indent}${indent}${indent}: $item,`);
               variableAssignments.push(`${indent}${indent}${indent}${indent}self::asArray(${dataExpr})`);
               variableAssignments.push(`${indent}${indent}${indent})`);

--- a/generator/src/writers/index.ts
+++ b/generator/src/writers/index.ts
@@ -574,7 +574,18 @@ ${indent}${indent}${indent}${indent}gettype($value)
 ${indent}${indent}${indent}));
 ${indent}${indent}}
 ${indent}${indent}/** @var array<int, string> */
-${indent}${indent}return array_values(array_map(static fn($item): string => (string) $item, $value));
+${indent}${indent}return array_values(array_map(static function ($item): string {
+${indent}${indent}${indent}if (is_scalar($item) || $item === null) {
+${indent}${indent}${indent}${indent}return (string) $item;
+${indent}${indent}${indent}}
+${indent}${indent}${indent}if (is_object($item) && method_exists($item, '__toString')) {
+${indent}${indent}${indent}${indent}return self::asString($item->__toString());
+${indent}${indent}${indent}}
+${indent}${indent}${indent}throw new \\InvalidArgumentException(sprintf(
+${indent}${indent}${indent}${indent}'Expected a value castable to string, got %s',
+${indent}${indent}${indent}${indent}gettype($item)
+${indent}${indent}${indent}));
+${indent}${indent}}, $value));
 ${indent}}
 
 ${indent}/**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,10 @@
 parameters:
     phpVersion: 70400
     level: max
+    # PHPDoc types on untyped PHP 7.4 properties describe the wire contract, not
+    # a guarantee about the runtime value. Serialization deliberately accepts an
+    # already-serialized array where the PHPDoc names a DTO union, so the checks
+    # guarding that are reachable even though the PHPDoc says otherwise.
+    treatPhpDocTypesAsCertain: false
     paths:
         - src

--- a/src/Client/Roots/DTO/ListRootsResult.php
+++ b/src/Client/Roots/DTO/ListRootsResult.php
@@ -60,7 +60,7 @@ class ListRootsResult extends Result implements ClientResultInterface
         /** @var array<\WP\McpSchema\Client\Roots\DTO\Root> $roots */
         $roots = array_map(
             static fn($item) => is_array($item)
-                ? Root::fromArray($item)
+                ? Root::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['roots'])
         );

--- a/src/Client/Sampling/DTO/CreateMessageRequestParams.php
+++ b/src/Client/Sampling/DTO/CreateMessageRequestParams.php
@@ -184,7 +184,7 @@ class CreateMessageRequestParams extends TaskAugmentedRequestParams
         /** @var array<\WP\McpSchema\Client\Sampling\DTO\SamplingMessage> $messages */
         $messages = array_map(
             static fn($item) => is_array($item)
-                ? SamplingMessage::fromArray($item)
+                ? SamplingMessage::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['messages'])
         );
@@ -219,7 +219,7 @@ class CreateMessageRequestParams extends TaskAugmentedRequestParams
         $tools = isset($data['tools'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Tool::fromArray($item)
+                    ? Tool::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['tools'])
             )

--- a/src/Client/Sampling/DTO/CreateMessageResult.php
+++ b/src/Client/Sampling/DTO/CreateMessageResult.php
@@ -109,7 +109,7 @@ class CreateMessageResult extends Result implements ClientResultInterface
         /** @var array<\WP\McpSchema\Common\Protocol\Union\SamplingMessageContentBlockInterface|\WP\McpSchema\Common\Protocol\Union\SamplingMessageContentBlockInterface> $content */
         $content = array_map(
             static fn($item) => is_array($item)
-                ? SamplingMessageContentBlockFactory::fromArray($item)
+                ? SamplingMessageContentBlockFactory::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['content'])
         );

--- a/src/Client/Sampling/DTO/ModelPreferences.php
+++ b/src/Client/Sampling/DTO/ModelPreferences.php
@@ -115,7 +115,7 @@ class ModelPreferences extends AbstractDataTransferObject
         $hints = isset($data['hints'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? ModelHint::fromArray($item)
+                    ? ModelHint::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['hints'])
             )

--- a/src/Client/Sampling/DTO/SamplingMessage.php
+++ b/src/Client/Sampling/DTO/SamplingMessage.php
@@ -81,7 +81,7 @@ class SamplingMessage extends AbstractDataTransferObject
         /** @var array<\WP\McpSchema\Common\Protocol\Union\SamplingMessageContentBlockInterface|\WP\McpSchema\Common\Protocol\Union\SamplingMessageContentBlockInterface> $content */
         $content = array_map(
             static fn($item) => is_array($item)
-                ? SamplingMessageContentBlockFactory::fromArray($item)
+                ? SamplingMessageContentBlockFactory::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['content'])
         );

--- a/src/Client/Sampling/DTO/ToolResultContent.php
+++ b/src/Client/Sampling/DTO/ToolResultContent.php
@@ -136,7 +136,7 @@ class ToolResultContent extends AbstractDataTransferObject implements SamplingMe
         /** @var array<\WP\McpSchema\Common\Protocol\Union\ContentBlockInterface> $content */
         $content = array_map(
             static fn($item) => is_array($item)
-                ? ContentBlockFactory::fromArray($item)
+                ? ContentBlockFactory::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['content'])
         );

--- a/src/Common/Lifecycle/DTO/Implementation.php
+++ b/src/Common/Lifecycle/DTO/Implementation.php
@@ -113,7 +113,7 @@ class Implementation extends BaseMetadata
         $icons = isset($data['icons'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Icon::fromArray($item)
+                    ? Icon::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['icons'])
             )

--- a/src/Common/Protocol/DTO/Icons.php
+++ b/src/Common/Protocol/DTO/Icons.php
@@ -62,7 +62,7 @@ class Icons extends AbstractDataTransferObject
         $icons = isset($data['icons'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Icon::fromArray($item)
+                    ? Icon::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['icons'])
             )

--- a/src/Common/Tasks/DTO/ListTasksResult.php
+++ b/src/Common/Tasks/DTO/ListTasksResult.php
@@ -62,7 +62,7 @@ class ListTasksResult extends PaginatedResult implements ClientResultInterface, 
         /** @var array<\WP\McpSchema\Client\Tasks\DTO\Task> $tasks */
         $tasks = array_map(
             static fn($item) => is_array($item)
-                ? Task::fromArray($item)
+                ? Task::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['tasks'])
         );

--- a/src/Common/Traits/ValidatesRequiredFields.php
+++ b/src/Common/Traits/ValidatesRequiredFields.php
@@ -234,7 +234,18 @@ trait ValidatesRequiredFields
             ));
         }
         /** @var array<int, string> */
-        return array_values(array_map(static fn($item): string => (string) $item, $value));
+        return array_values(array_map(static function ($item): string {
+            if (is_scalar($item) || $item === null) {
+                return (string) $item;
+            }
+            if (is_object($item) && method_exists($item, '__toString')) {
+                return self::asString($item->__toString());
+            }
+            throw new \InvalidArgumentException(sprintf(
+                'Expected a value castable to string, got %s',
+                gettype($item)
+            ));
+        }, $value));
     }
 
     /**

--- a/src/Server/Prompts/DTO/GetPromptResult.php
+++ b/src/Server/Prompts/DTO/GetPromptResult.php
@@ -71,7 +71,7 @@ class GetPromptResult extends Result implements ServerResultInterface
         /** @var array<\WP\McpSchema\Server\Prompts\DTO\PromptMessage> $messages */
         $messages = array_map(
             static fn($item) => is_array($item)
-                ? PromptMessage::fromArray($item)
+                ? PromptMessage::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['messages'])
         );

--- a/src/Server/Prompts/DTO/ListPromptsResult.php
+++ b/src/Server/Prompts/DTO/ListPromptsResult.php
@@ -61,7 +61,7 @@ class ListPromptsResult extends PaginatedResult implements ServerResultInterface
         /** @var array<\WP\McpSchema\Server\Prompts\DTO\Prompt> $prompts */
         $prompts = array_map(
             static fn($item) => is_array($item)
-                ? Prompt::fromArray($item)
+                ? Prompt::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['prompts'])
         );

--- a/src/Server/Prompts/DTO/Prompt.php
+++ b/src/Server/Prompts/DTO/Prompt.php
@@ -111,7 +111,7 @@ class Prompt extends BaseMetadata
         $arguments = isset($data['arguments'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? PromptArgument::fromArray($item)
+                    ? PromptArgument::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['arguments'])
             )
@@ -121,7 +121,7 @@ class Prompt extends BaseMetadata
         $icons = isset($data['icons'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Icon::fromArray($item)
+                    ? Icon::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['icons'])
             )

--- a/src/Server/Resources/DTO/ListResourceTemplatesResult.php
+++ b/src/Server/Resources/DTO/ListResourceTemplatesResult.php
@@ -61,7 +61,7 @@ class ListResourceTemplatesResult extends PaginatedResult implements ServerResul
         /** @var array<\WP\McpSchema\Server\Resources\DTO\ResourceTemplate> $resourceTemplates */
         $resourceTemplates = array_map(
             static fn($item) => is_array($item)
-                ? ResourceTemplate::fromArray($item)
+                ? ResourceTemplate::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['resourceTemplates'])
         );

--- a/src/Server/Resources/DTO/ListResourcesResult.php
+++ b/src/Server/Resources/DTO/ListResourcesResult.php
@@ -61,7 +61,7 @@ class ListResourcesResult extends PaginatedResult implements ServerResultInterfa
         /** @var array<\WP\McpSchema\Server\Resources\DTO\Resource> $resources */
         $resources = array_map(
             static fn($item) => is_array($item)
-                ? Resource::fromArray($item)
+                ? Resource::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['resources'])
         );

--- a/src/Server/Resources/DTO/Resource.php
+++ b/src/Server/Resources/DTO/Resource.php
@@ -162,7 +162,7 @@ class Resource extends BaseMetadata
         $icons = isset($data['icons'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Icon::fromArray($item)
+                    ? Icon::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['icons'])
             )

--- a/src/Server/Resources/DTO/ResourceLink.php
+++ b/src/Server/Resources/DTO/ResourceLink.php
@@ -96,7 +96,7 @@ class ResourceLink extends Resource implements ContentBlockInterface
         $icons = isset($data['icons'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Icon::fromArray($item)
+                    ? Icon::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['icons'])
             )

--- a/src/Server/Resources/DTO/ResourceTemplate.php
+++ b/src/Server/Resources/DTO/ResourceTemplate.php
@@ -147,7 +147,7 @@ class ResourceTemplate extends BaseMetadata
         $icons = isset($data['icons'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Icon::fromArray($item)
+                    ? Icon::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['icons'])
             )

--- a/src/Server/Tools/DTO/CallToolResult.php
+++ b/src/Server/Tools/DTO/CallToolResult.php
@@ -99,7 +99,7 @@ class CallToolResult extends Result implements ServerResultInterface
         /** @var array<\WP\McpSchema\Common\Protocol\Union\ContentBlockInterface> $content */
         $content = array_map(
             static fn($item) => is_array($item)
-                ? ContentBlockFactory::fromArray($item)
+                ? ContentBlockFactory::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['content'])
         );

--- a/src/Server/Tools/DTO/ListToolsResult.php
+++ b/src/Server/Tools/DTO/ListToolsResult.php
@@ -61,7 +61,7 @@ class ListToolsResult extends PaginatedResult implements ServerResultInterface
         /** @var array<\WP\McpSchema\Server\Tools\DTO\Tool> $tools */
         $tools = array_map(
             static fn($item) => is_array($item)
-                ? Tool::fromArray($item)
+                ? Tool::fromArray(self::asArray($item))
                 : $item,
             self::asArray($data['tools'])
         );

--- a/src/Server/Tools/DTO/Tool.php
+++ b/src/Server/Tools/DTO/Tool.php
@@ -184,7 +184,7 @@ class Tool extends BaseMetadata
         $icons = isset($data['icons'])
             ? array_map(
                 static fn($item) => is_array($item)
-                    ? Icon::fromArray($item)
+                    ? Icon::fromArray(self::asArray($item))
                     : $item,
                 self::asArray($data['icons'])
             )


### PR DESCRIPTION
Raises the PHPStan dev dependency to `^2.0`. `level: max` is level 10 there, and `src/` analyses clean at it.

## How it works

Three adjustments cover the stricter rules.

`asStringArray()` narrows each element before converting it. Scalars and null convert directly, an object declaring `__toString()` converts through it, and anything else raises `InvalidArgumentException`. Nothing reaches a cast from `mixed`.

Hydration of DTO arrays passes each element through `self::asArray()`, which asserts `array<string, mixed>` and so satisfies the `fromArray()` parameter. The single-DTO hydration paths take the same route.

`treatPhpDocTypesAsCertain` is off. PHPDoc types on untyped PHP 7.4 properties describe the wire contract, not the runtime value: serialization accepts an already-serialized array where the PHPDoc names a DTO union, so the checks guarding that are reachable.

## Compatibility

PHPStan 2 runs on PHP 7.4 and 8.x, so the CI matrix is unchanged.

`asStringArray()` carries the one behavior change. Every value that converts cleanly keeps its result:

| Input | Result |
| --- | --- |
| `['a', 'b']` | `['a', 'b']` |
| `[1, 2]` | `['1', '2']` |
| `[1.5]` | `['1.5']` |
| `[true, false]` | `['1', '']` |
| `[null]` | `['']` |
| object declaring `__toString()` | its string value |
| `[[1, 2]]`, `[new stdClass()]` | `InvalidArgumentException` |

The last row is the change: an array or an object with no `__toString()` is rejected rather than converted.

## Note for reviewers

`src/` is generator output. The generator change and the regenerated PHP are committed together so a clean `npm run generate` reproduces the tree.

This branch and `#9` overlap on 10 generated files and on both `generator/src/generators/dto.ts` and `generator/src/writers/index.ts`, so the ordering is worth stating. A trial merge of the two runs clean, a fresh `npm run generate` from the merged generator reproduces the merged tree byte for byte, and `composer analyse` is clean on the combined result. Either can land first.
