### PR TITLE
Document the method to record map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,7 @@ composer test
 composer analyse
 composer validate --strict
 composer autoload:verify
+composer artifact:verify
 git diff --check
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Supported revisions:
 Unknown identifiers are rejected. The runtime never selects a revision by a
 range or nearest-version rule.
 
-### Older revisions
+## Older revisions
 
 Revisions before `2025-11-25` (`2024-10-07`, `2024-11-05`, `2025-03-26`, and
 `2025-06-18`) are not accepted as identifiers and have no schema of their own.

--- a/README.md
+++ b/README.md
@@ -29,17 +29,12 @@ package's.
 
 ## Installation
 
-> **Unreleased branch API:** the examples below describe the current development
-> branch.
-> The latest tagged Composer release still exposes the previous public API.
-> Until this work is released, consume only an exact reviewed branch commit
-> through a VCS repository reference.
-
-After the runtime is released:
-
 ```bash
 composer require wordpress/php-mcp-schema
 ```
+
+The runtime described below ships in 0.2.0 and later. Releases before 0.2.0
+expose the removed DTO API; see the [migration guide](docs/MIGRATION.md).
 
 ## Select and use a schema
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ $schema->allowsEmbeddedInput('elicitation/create');
 
 For example, `ping` is valid under `2025-11-25` and absent under `2026-07-28`;
 `server/discover` is valid under `2026-07-28` and absent under `2025-11-25`.
+The [method to record map](docs/methods.md) lists every method with its
+request, result, or notification record and its revision availability.
 
 ## Public namespaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -244,8 +244,9 @@ can therefore gain nullability or a PHPDoc union without a native return type.
 For example, `Tool::getMeta()` represents `MetaObject|stdClass|null` in PHPDoc.
 
 Contributors must review the generated public API diff as well as the
-compatibility manifest, and update the [method to record map](methods.md). Passing the generation gate does not establish that
-every getter signature is unchanged. Normal package versioning applies when a
+compatibility manifest, and update the [method to record map](methods.md).
+Passing the generation gate does not establish that every getter signature is
+unchanged. Normal package versioning applies when a
 new revision requires a public API break.
 
 Removing a revision is also potentially breaking. Records, contracts, or values

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -244,7 +244,7 @@ can therefore gain nullability or a PHPDoc union without a native return type.
 For example, `Tool::getMeta()` represents `MetaObject|stdClass|null` in PHPDoc.
 
 Contributors must review the generated public API diff as well as the
-compatibility manifest. Passing the generation gate does not establish that
+compatibility manifest, and update the [method to record map](methods.md). Passing the generation gate does not establish that
 every getter signature is unchanged. Normal package versioning applies when a
 new revision requires a public API break.
 

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -1,0 +1,89 @@
+# Method to record map
+
+Which record class carries each JSON-RPC method, and in which revision. Every
+record lives under `WP\McpSchema\Record`. Construct requests and notifications
+with the request record; select the result record from the originating method,
+as described in the [migration guide](MIGRATION.md#validate-results-for-the-originating-method).
+
+A method is valid in a direction only where the row marks it. The same checks
+are available at runtime through `Schema::allowsClientRequest()` and its
+siblings.
+
+## Client to server requests
+
+| Method | Request record | Result record | 2025-11-25 | 2026-07-28 |
+| --- | --- | --- | --- | --- |
+| `completion/complete` | `CompleteRequest` | `CompleteResult` | yes | yes |
+| `initialize` | `InitializeRequest` | `InitializeResult` | yes | no |
+| `logging/setLevel` | `SetLevelRequest` | `EmptyResult` | yes | no |
+| `ping` | `PingRequest` | `EmptyResult` | yes | no |
+| `prompts/get` | `GetPromptRequest` | `GetPromptResult` | yes | yes |
+| `prompts/list` | `ListPromptsRequest` | `ListPromptsResult` | yes | yes |
+| `resources/list` | `ListResourcesRequest` | `ListResourcesResult` | yes | yes |
+| `resources/read` | `ReadResourceRequest` | `ReadResourceResult` | yes | yes |
+| `resources/subscribe` | `SubscribeRequest` | `EmptyResult` | yes | no |
+| `resources/templates/list` | `ListResourceTemplatesRequest` | `ListResourceTemplatesResult` | yes | yes |
+| `resources/unsubscribe` | `UnsubscribeRequest` | `EmptyResult` | yes | no |
+| `server/discover` | `DiscoverRequest` | `DiscoverResult` | no | yes |
+| `subscriptions/listen` | `SubscriptionsListenRequest` | `SubscriptionsListenResult` | no | yes |
+| `tasks/cancel` | `CancelTaskRequest` | `CancelTaskResult` | yes | no |
+| `tasks/get` | `GetTaskRequest` | `GetTaskResult` | yes | no |
+| `tasks/list` | `ListTasksRequest` | `ListTasksResult` | yes | no |
+| `tasks/result` | `GetTaskPayloadRequest` | `GetTaskPayloadResult` | yes | no |
+| `tools/call` | `CallToolRequest` | `CallToolResult` | yes | yes |
+| `tools/list` | `ListToolsRequest` | `ListToolsResult` | yes | yes |
+
+Under `2025-11-25`, a task-augmented `tools/call` returns `CreateTaskResult`
+instead of `CallToolResult`. Under `2026-07-28`, `tools/call`, `prompts/get`,
+and `resources/read` may return `InputRequiredResult` instead of their result
+record; see the migration guide section on protocol workflow rules.
+
+## Server to client requests
+
+| Method | Request record | Result record | 2025-11-25 | 2026-07-28 |
+| --- | --- | --- | --- | --- |
+| `elicitation/create` | `ElicitRequest` | `ElicitResult` | yes | embedded |
+| `ping` | `PingRequest` | `EmptyResult` | yes | no |
+| `roots/list` | `ListRootsRequest` | `ListRootsResult` | yes | embedded |
+| `sampling/createMessage` | `CreateMessageRequest` | `CreateMessageResult` | yes | embedded |
+| `tasks/cancel` | `CancelTaskRequest` | `CancelTaskResult` | yes | no |
+| `tasks/get` | `GetTaskRequest` | `GetTaskResult` | yes | no |
+| `tasks/list` | `ListTasksRequest` | `ListTasksResult` | yes | no |
+| `tasks/result` | `GetTaskPayloadRequest` | `GetTaskPayloadResult` | yes | no |
+
+`2026-07-28` has no server to client JSON-RPC requests. The three methods marked
+"embedded" travel inside an `InputRequiredResult` and are checked with
+`Schema::allowsEmbeddedInput()`.
+
+## Client to server notifications
+
+| Method | Record | 2025-11-25 | 2026-07-28 |
+| --- | --- | --- | --- |
+| `notifications/cancelled` | `CancelledNotification` | yes | `ClientNotification` |
+| `notifications/initialized` | `InitializedNotification` | yes | no |
+| `notifications/progress` | `ProgressNotification` | yes | no |
+| `notifications/roots/list_changed` | `RootsListChangedNotification` | yes | no |
+| `notifications/tasks/status` | `TaskStatusNotification` | yes | no |
+
+Under `2026-07-28`, `notifications/cancelled` is the only client notification
+and the catalog binds it to the object root `Record\ClientNotification`.
+`Record\CancelledNotification` remains available in both revisions for the
+concrete message.
+
+## Server to client notifications
+
+| Method | Record | 2025-11-25 | 2026-07-28 |
+| --- | --- | --- | --- |
+| `notifications/cancelled` | `CancelledNotification` | yes | yes |
+| `notifications/elicitation/complete` | `ElicitationCompleteNotification` | yes | no |
+| `notifications/message` | `LoggingMessageNotification` | yes | yes |
+| `notifications/progress` | `ProgressNotification` | yes | yes |
+| `notifications/prompts/list_changed` | `PromptListChangedNotification` | yes | yes |
+| `notifications/resources/list_changed` | `ResourceListChangedNotification` | yes | yes |
+| `notifications/resources/updated` | `ResourceUpdatedNotification` | yes | yes |
+| `notifications/subscriptions/acknowledged` | `SubscriptionsAcknowledgedNotification` | no | yes |
+| `notifications/tasks/status` | `TaskStatusNotification` | yes | no |
+| `notifications/tools/list_changed` | `ToolListChangedNotification` | yes | yes |
+
+Update this file when a revision is added or removed. The test suite checks
+that every method in the catalogs appears here with its record name.

--- a/tests/artifact/verify.sh
+++ b/tests/artifact/verify.sh
@@ -43,6 +43,7 @@ printf '%s\n' \
     composer.json \
     docs/MIGRATION.md \
     docs/architecture.md \
+    docs/methods.md \
     generator/README.md > "$expected"
 find "$source_root/src" -type f -print \
     | sed "s|^$source_root/||" \

--- a/tests/phpunit/Architecture/MethodMapDocumentationTest.php
+++ b/tests/phpunit/Architecture/MethodMapDocumentationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\McpSchema\Tests\Architecture;
+
+use PHPUnit\Framework\TestCase;
+use WP\McpSchema\Internal\Catalog\V2025_11_25;
+use WP\McpSchema\Internal\Catalog\V2026_07_28;
+
+final class MethodMapDocumentationTest extends TestCase
+{
+    public function test_every_catalog_method_is_documented_with_its_record(): void
+    {
+        $document = (string) file_get_contents(dirname(__DIR__, 3) . '/docs/methods.md');
+
+        foreach (array(V2025_11_25::messageAvailability(), V2026_07_28::messageAvailability()) as $availability) {
+            $maps = array(
+                $availability['clientToServer']['requests'],
+                $availability['clientToServer']['notifications'],
+                $availability['serverToClient']['requests'],
+                $availability['serverToClient']['notifications'],
+                $availability['embeddedInputs'],
+            );
+            foreach ($maps as $map) {
+                foreach ($map as $method => $definition) {
+                    self::assertStringContainsString(sprintf('| `%s` |', $method), $document, $method);
+                    self::assertStringContainsString(sprintf('`%s`', $definition), $document, $method);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `docs/methods.md`, a table of every JSON-RPC method with its request, result, or notification record and its availability under `2025-11-25` and `2026-07-28`. Linked from the README availability section and from the revision checklist in the architecture doc.

This replaces the one thing the removed `skill/` index covered that the code does not state in one place, as promised on #15.

## Decisions

- Hand-maintained Markdown, not generator output. A `MethodMapDocumentationTest` asserts that every method in both catalogs appears in the table with its record name, so drift fails the test suite without adding a generator stage.
- Result records come from the schema descriptions and the `EmptyResult` methods (`ping`, `logging/setLevel`, `resources/subscribe`, `resources/unsubscribe`). The task-augmented `CreateTaskResult` and the `2026-07-28` `InputRequiredResult` cases are noted below the table rather than as rows.
- The `2026-07-28` client notification row shows `ClientNotification` because that is what the catalog binds; `CancelledNotification` stays available in both revisions.

## Testing

- `composer test` on PHP 8.5 and 7.4: 83 tests, 715 assertions, all passing, including the new documentation test.
